### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,15 +5,15 @@ T-Service
     :target: https://travis-ci.org/jiffyclub/tservice
     :alt: Build Status
 
-.. image:: https://pypip.in/version/tservice/badge.svg
+.. image:: https://img.shields.io/pypi/v/tservice.svg
     :target: https://pypi.python.org/pypi/tservice/
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/tservice/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/tservice.svg
     :target: https://pypi.python.org/pypi/tservice/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/wheel/tservice/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/tservice.svg
     :target: https://pypi.python.org/pypi/tservice/
     :alt: Wheel Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20tservice))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `tservice`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.